### PR TITLE
Camera metadata: Check source metadata size

### DIFF
--- a/camera/src/camera_metadata.c
+++ b/camera/src/camera_metadata.c
@@ -183,6 +183,12 @@ camera_metadata_t *allocate_copy_camera_metadata_checked(
         return NULL;
     }
 
+    if (src_size < sizeof(camera_metadata_t)) {
+        ALOGE("%s: Source size too small!", __FUNCTION__);
+        android_errorWriteLog(0x534e4554, "67782345");
+        return NULL;
+    }
+
     void *buffer = malloc(src_size);
     memcpy(buffer, src, src_size);
 


### PR DESCRIPTION
Source size passed by client could be smaller than 'camera_metadata_t'.
In this case the cast in 'allocate_copy_camera_metadata_checked()' will
be incorrect and we will try to access invalid heap memory.

Bug: 67782345
Test: Camera CTS
Change-Id: I9582c704f414493978d09ffb603b5e8368cda5ce
(cherry picked from commit 489bbd13bf0add8029444b9d9505b3d118776ea3)